### PR TITLE
Prepare for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - cargo check --tests --examples
   - cargo test --lib --tests
   - cargo test --doc
-  - cargo run --no-default-features --features rand-06 --example ed25519 > /dev/null
+  - cargo run --no-default-features --features rand-06,rand --example ed25519 > /dev/null
   - cargo clean --doc && cargo doc --no-deps && cargo deadlinks --dir target/doc
 
 deploy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha = { version = "0.2.0", optional = true }
 [dev-dependencies]
 hex = "0.3.2"
 ed25519 = { package = "ed25519-dalek", version = "1.0.0-pre.1" }
-pwbox = { version = "0.1.4", default-features = false, features = ["rust-crypto"] }
+pwbox = { version = "0.2.1", default-features = false, features = ["rust-crypto"] }
 toml = "0.5.1"
 
 [features]
@@ -35,4 +35,4 @@ rand-07 = ["rand", "rand_chacha"]
 [[example]]
 name = "ed25519"
 path = "examples/ed25519.rs"
-required-features = ["rand-06"]
+required-features = ["rand-06", "rand"]

--- a/examples/ed25519.rs
+++ b/examples/ed25519.rs
@@ -76,7 +76,7 @@ fn main() {
 
     // Assume that we have securely persisted the RNG tree (e.g., with passphrase encryption).
     let passphrase = "correct horse battery staple";
-    let secured_store = RustCrypto::build_box(&mut rng)
+    let secured_store = RustCrypto::build_box(&mut rand::thread_rng())
         .kdf(if cfg!(debug_assertions) {
             // Ultra-light parameters to get the test run fast in the debug mode.
             Scrypt::custom(6, 16)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,17 +132,22 @@ use clear_on_drop::ClearOnDrop;
 // in the public interface of `SecretTree`. If one wants to use the crate with rand v0.6,
 // he has no other choice than to manually downgrade via `cargo update rand:0.7.x --precise 0.6.x`,
 // and even this may not work (v0.7 may be used elsewhere).
-//
-// Older versions:
-#[cfg(feature = "rand-06")]
-use rand6::{AsByteSliceMut, CryptoRng, RngCore, SeedableRng};
-#[cfg(feature = "rand-06")]
-use rand6_chacha::ChaChaRng;
-// Newer versions:
-#[cfg(feature = "rand-07")]
-use rand::{AsByteSliceMut, CryptoRng, RngCore, SeedableRng};
-#[cfg(feature = "rand-07")]
-use rand_chacha::ChaChaRng;
+mod imports {
+    // Older versions:
+    #[cfg(feature = "rand-06")]
+    pub use rand6 as rand;
+    #[cfg(feature = "rand-06")]
+    pub use rand6_chacha as rand_chacha;
+    // Newer versions:
+    #[cfg(feature = "rand-07")]
+    pub use rand;
+    #[cfg(feature = "rand-07")]
+    pub use rand_chacha;
+}
+use self::imports::{
+    rand::{AsByteSliceMut, CryptoRng, RngCore, SeedableRng},
+    rand_chacha::ChaChaRng,
+};
 
 use core::fmt;
 


### PR DESCRIPTION
This PR contains preparations for `0.2.0` release.

Supersedes #4, #5.