### PR TITLE
Update `rand` dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  msrv: 1.46.0
+  nightly: nightly-2020-10-24
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,19 +48,19 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-targets -- -D warnings
+          args: --all --all-targets --features rand/std,rand/std_rng -- -D warnings
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all --features rand/std,rand/std_rng
 
       - name: Run example
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --no-default-features --example ed25519
+          args: --no-default-features --features rand/std,rand/std_rng --example ed25519
 
       - name: Check docs
         run: cargo clean --doc && cargo doc --no-deps && cargo deadlinks --dir target/doc
@@ -76,7 +80,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.46.0
+          toolchain: ${{ env.msrv }}
           profile: minimal
           override: true
 
@@ -89,7 +93,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --example ed25519
+          args: --features rand/std,rand/std_rng --example ed25519
 
   # Checks that the crate actually builds without `std`. To do this,
   # we take a target (`thumbv7m-none-eabi`) that does not have `std` support.
@@ -110,7 +114,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-24
+          toolchain: ${{ env.nightly }}
           profile: minimal
           override: true
           target: thumbv7m-none-eabi
@@ -143,7 +147,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-24
+          toolchain: ${{ env.nightly }}
           profile: minimal
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ repository = "https://github.com/slowli/secret-tree"
 
 [dependencies]
 # Public dependencies (present in the API exposed by the crate).
-rand = { version = "0.7.3", default-features = false }
-rand_chacha = { version = "0.2.2", default-features = false }
+rand = { version = "0.8.1", default-features = false }
+rand_chacha = { version = "0.3.0", default-features = false }
 
 # Private dependencies.
 blake2 = { version = "0.9.1", default-features = false }
@@ -27,7 +27,7 @@ secrecy = { version = "0.7.0", default-features = false }
 hex = "0.4.2"
 hex-literal = "0.3.1"
 ed25519 = { package = "ed25519-dalek", version = "1.0.1" }
-pwbox = { version = "0.3.0", default-features = false, features = ["rust-crypto"] }
+pwbox = { version = "0.4.0", default-features = false, features = ["std", "rust-crypto"] }
 toml = "0.5.7"
 version-sync = "0.9"
 
@@ -38,3 +38,4 @@ std = []
 [[example]]
 name = "ed25519"
 path = "examples/ed25519.rs"
+required-features = ["rand/std", "rand/std_rng"]

--- a/src/byte_slice.rs
+++ b/src/byte_slice.rs
@@ -1,0 +1,113 @@
+// Copyright 2021 Alex Ostrovski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Operations on byte slices.
+
+use core::{mem, slice};
+
+/// Converts a type to a mutable byte slice. This is used within the crate to fill
+/// secret values with the RNG output.
+///
+/// This trait is implemented for numeric types (`u8`, `i8`, ..., `u128`, `i128`), slices
+/// of these types, and arrays of small sizes (1..=64).
+// This is an ad-hoc replacement for the eponymous trait from `rand` v0.7, which was removed
+// in `rand` v0.8.
+pub trait AsByteSliceMut {
+    /// Performs conversion to a mutable byte slice.
+    fn as_byte_slice_mut(&mut self) -> &mut [u8];
+
+    /// Converts values within this type to the little-endian byte order.
+    ///
+    /// This methods is called after filling bytes to achieve uniform behavior across
+    /// big-endian and little-endian platforms.
+    fn convert_to_le(&mut self);
+}
+
+impl AsByteSliceMut for [u8] {
+    fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+        self
+    }
+
+    fn convert_to_le(&mut self) {
+        // No-op.
+    }
+}
+
+macro_rules! impl_as_byte_slice {
+    ($ty:ty) => {
+        impl AsByteSliceMut for [$ty] {
+            fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+                if self.is_empty() {
+                    // Empty slices need special handling since `from_raw_parts_mut` doesn't accept
+                    // an empty pointer.
+                    &mut []
+                } else {
+                    let byte_len = self.len() * mem::size_of::<$ty>();
+                    let data = self as *mut [$ty] as *mut u8;
+                    unsafe { slice::from_raw_parts_mut(data, byte_len) }
+                }
+            }
+
+            fn convert_to_le(&mut self) {
+                for element in self {
+                    *element = element.to_le();
+                }
+            }
+        }
+    };
+
+    ($($t:ty,)*) => {
+        $(impl_as_byte_slice!($t);)*
+    };
+}
+
+impl_as_byte_slice!(i8, u16, i16, u32, i32, u64, i64, u128, i128,);
+
+impl<T> AsByteSliceMut for T
+where
+    [T]: AsByteSliceMut,
+{
+    fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+        AsByteSliceMut::as_byte_slice_mut(slice::from_mut(self))
+    }
+
+    fn convert_to_le(&mut self) {
+        AsByteSliceMut::convert_to_le(slice::from_mut(self))
+    }
+}
+
+macro_rules! impl_as_byte_slice_array {
+    ($($n:expr,)*) => {
+        $(
+        impl<T> AsByteSliceMut for [T; $n]
+        where
+            [T]: AsByteSliceMut,
+        {
+            fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+                AsByteSliceMut::as_byte_slice_mut(&mut self[..])
+            }
+
+            fn convert_to_le(&mut self) {
+                AsByteSliceMut::convert_to_le(&mut self[..])
+            }
+        }
+        )*
+    };
+}
+
+impl_as_byte_slice_array!(
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+    51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+);


### PR DESCRIPTION
This also introduces an ad-hoc `AsByteSliceMut` trait instead of the one removed from `rand`.

supersedes #12  
supersedes #14 
supersedes #15