### PR TITLE
Fix CI build

### DIFF
--- a/src/byte_slice.rs
+++ b/src/byte_slice.rs
@@ -69,7 +69,7 @@ where
     }
 
     fn convert_to_le(&mut self) {
-        AsByteSliceMut::convert_to_le(slice::from_mut(self))
+        AsByteSliceMut::convert_to_le(slice::from_mut(self));
     }
 }
 


### PR DESCRIPTION
A new clippy lint was introduced in Rust 1.54, which is now fixed.