### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - name: Install cargo-deny
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
           version: "^0.18"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.6.0 - 2025-11-04
+
 ### Changed
 
 - Update `secrecy` version to 0.10; change `Secret` to `SecretBox` accordingly, and make `Seed` a struct
   instead of a type alias. 
+- Update `rand_core` version to 0.9.
 - Bump MSRV to 1.70.
 
 ## 0.5.0 - 2022-07-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "secret-tree"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blake2",
  "const-decoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "secret-tree"
 edition = "2021"
 rust-version = "1.70"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   "Alex Ostrovski <ostrovski.alex@gmail.com>",
   "Pavel Mukhanov <mukhanovpv@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-secret-tree = "0.5.0"
+secret-tree = "0.6.0"
 ```
 
 Basic usage:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/secret-tree/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/secret-tree/0.6.0")]
 // Linter settings
 #![warn(missing_docs, missing_debug_implementations)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
## What?

Prepares the next crate release.

## Why?

There are some breaking changes (e.g., updating `rand` crates).
