### PR TITLE
Fix CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hierarchical secret derivation with Blake2b
 
-[![Build Status](https://github.com/slowli/secret-tree/workflows/CI/badge.svg?branch=master)](https://github.com/slowli/secret-tree/actions)
+[![Build status](https://github.com/slowli/secret-tree/actions/workflows/ci.yml/badge.svg)](https://github.com/slowli/secret-tree/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/github/license/slowli/secret-tree.svg)](https://github.com/slowli/secret-tree/blob/master/LICENSE)
 ![rust 1.70+ required](https://img.shields.io/badge/rust-1.70+-blue.svg)
 ![no_std supported](https://img.shields.io/badge/no__std-tested-green.svg)


### PR DESCRIPTION
## What?

Fixes the CI status badge in the crate readme.

## Why?

The badge doesn't currently work.
